### PR TITLE
Use sqlite3 v 2.5.0 to fix CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "rubocop-rails-omakase", require: false
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
 
-gem "sqlite3"
+gem "sqlite3", "2.5.0"
 
 group :development, :test do
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,14 +298,14 @@ GEM
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    sqlite3 (2.6.0-aarch64-linux-gnu)
-    sqlite3 (2.6.0-aarch64-linux-musl)
-    sqlite3 (2.6.0-arm-linux-gnu)
-    sqlite3 (2.6.0-arm-linux-musl)
-    sqlite3 (2.6.0-arm64-darwin)
-    sqlite3 (2.6.0-x86_64-darwin)
-    sqlite3 (2.6.0-x86_64-linux-gnu)
-    sqlite3 (2.6.0-x86_64-linux-musl)
+    sqlite3 (2.5.0-aarch64-linux-gnu)
+    sqlite3 (2.5.0-aarch64-linux-musl)
+    sqlite3 (2.5.0-arm-linux-gnu)
+    sqlite3 (2.5.0-arm-linux-musl)
+    sqlite3 (2.5.0-arm64-darwin)
+    sqlite3 (2.5.0-x86_64-darwin)
+    sqlite3 (2.5.0-x86_64-linux-gnu)
+    sqlite3 (2.5.0-x86_64-linux-musl)
     stringio (3.1.6)
     thor (1.3.2)
     timeout (0.4.3)
@@ -336,7 +336,7 @@ DEPENDENCIES
   pry
   rspec-rails
   rubocop-rails-omakase
-  sqlite3
+  sqlite3 (= 2.5.0)
   tidewave!
 
 BUNDLED WITH


### PR DESCRIPTION
Issue is due to [this change in sqlite3 v2.6.0](https://github.com/sparklemotion/sqlite3-ruby/pull/605/files) which generated issues with missing native dependencies