### PR TITLE
Drop `Faraday` in favor of `Net::HTTP` for RubyGems API calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     tidewave (0.1.0)
-      faraday (~> 2.13.0)
       fast-mcp (~> 1.3.0)
       rack (>= 2.0)
       rails (>= 7.2.0)
@@ -123,12 +122,6 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.13.1)
-    faraday (2.13.1)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
     fast-mcp (1.3.0)
       base64
       dry-schema (~> 1.14)
@@ -164,8 +157,6 @@ GEM
     mime-types-data (3.2025.0408)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    net-http (0.6.0)
-      uri
     net-imap (0.5.7)
       date
       net-protocol

--- a/spec/tools/package_search_spec.rb
+++ b/spec/tools/package_search_spec.rb
@@ -55,34 +55,35 @@ describe Tidewave::Tools::PackageSearch do
 
   describe "#call" do
     let(:response_body) { File.read("spec/fixtures/package_search.json") }
+    let(:parsed_response) { JSON.parse(response_body) }
+    let(:http_response) { instance_double('Net::HTTPSuccess') }
+
+    before do
+      allow(http_response).to receive(:body).and_return(response_body)
+      allow(http_response).to receive(:is_a?).with(Net::HTTPSuccess).and_return(true)
+    end
 
     context "without page" do
       it "returns results for page 1" do
-        faraday_double = instance_double('Faraday::Connection')
-        response = instance_double('Faraday::Response')
-        expect(faraday_double).to receive(:get).with("/api/v1/search.json?query=rails&page=1").and_return(response)
-        expect(response).to receive(:body).and_return(response_body)
+        uri = URI("https://rubygems.org/api/v1/search.json")
+        uri.query = URI.encode_www_form(query: "rails", page: 1)
 
-        expect(Faraday).to receive(:new).and_return(faraday_double)
+        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(http_response)
 
         result = described_class.new.call(search: "rails")
-
-        expect(result).to eq(response_body)
+        expect(result).to eq(parsed_response)
       end
     end
 
     context "with page" do
       it "returns results for the given page" do
-        faraday_double = instance_double('Faraday::Connection')
-        response = instance_double('Faraday::Response')
-        expect(faraday_double).to receive(:get).with("/api/v1/search.json?query=rails&page=2").and_return(response)
-        expect(response).to receive(:body).and_return(response_body)
+        uri = URI("https://rubygems.org/api/v1/search.json")
+        uri.query = URI.encode_www_form(query: "rails", page: 2)
 
-        allow(Faraday).to receive(:new).and_return(faraday_double)
+        expect(Net::HTTP).to receive(:get_response).with(uri).and_return(http_response)
 
         result = described_class.new.call(search: "rails", page: 2)
-
-        expect(result).to eq(response_body)
+        expect(result).to eq(parsed_response)
       end
     end
   end

--- a/tidewave.gemspec
+++ b/tidewave.gemspec
@@ -22,6 +22,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", ">= 7.2.0"
   spec.add_dependency "fast-mcp", "~> 1.3.0"
-  spec.add_dependency "faraday", "~> 2.13.0"
   spec.add_dependency "rack", ">= 2.0"
 end


### PR DESCRIPTION
First thank you for creating such a cool tool for the Rails eco system - really appreciate the work you're doing here!

Further Faraday is one of those gems that could lock a lot of Rails apps out of using this awesome tool due to other critical libs such as Omniauth and google api clients depending on older versions. Thus I think dropping it would be awesome for the project if the maintainers are ok with that.
