### PR TITLE
Loosen rails version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
@@ -12,20 +12,15 @@ jobs:
       matrix:
         ruby-version: [3.2.0, 3.3.0, 3.4.0]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    
-    - name: Install dependencies
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
-    
-    - name: Run tests
-      run: bundle exec rspec
-    
-    - name: Lint code for consistent style
-      run: bundle exec rubocop
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Run tests
+        run: bundle exec rspec
+
+      - name: Lint code for consistent style
+        run: bundle exec rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     tidewave (0.1.1)
       fast-mcp (~> 1.3.0)
       rack (>= 2.0)
-      rails (>= 7.2.0)
+      rails (>= 7.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/tidewave.gemspec
+++ b/tidewave.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "LICENSE", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 7.2.0"
+  spec.add_dependency "rails", ">= 7.1.0"
   spec.add_dependency "fast-mcp", "~> 1.3.0"
   spec.add_dependency "rack", ">= 2.0"
 end


### PR DESCRIPTION
This PR loosens up the min Rails required version and optimizes the CI workflow by removing the unnecessary bundle installations since the ruby setup job takes care of that.