### PR TITLE
Allow mtime as hidden argument and return it in metadata

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     tidewave (0.1.2)
-      fast-mcp (~> 1.3.0)
+      fast-mcp (~> 1.4.0)
       rack (>= 2.0)
       rails (>= 7.1.0)
 
@@ -126,7 +126,7 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.13.1)
-    fast-mcp (1.3.2)
+    fast-mcp (1.4.0)
       base64
       dry-schema (~> 1.14)
       json (~> 2.0)

--- a/spec/tools/get_source_location_spec.rb
+++ b/spec/tools/get_source_location_spec.rb
@@ -78,10 +78,10 @@ describe Tidewave::Tools::GetSourceLocation do
 
       context "when the module is found" do
         it "returns the correct result" do
-          expect(subject).to eq({
+          expect(subject).to eq([ {
             file_path: __FILE__,
             line_number: line_number
-          }.to_json)
+          }.to_json, {} ])
         end
       end
 

--- a/tidewave.gemspec
+++ b/tidewave.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.1.0"
-  spec.add_dependency "fast-mcp", "~> 1.3.0"
+  spec.add_dependency "fast-mcp", "~> 1.4.0"
   spec.add_dependency "rack", ">= 2.0"
 end


### PR DESCRIPTION
fast-mcp v1.4.0 supports returning metadata and accepts hidden arguments for tool calls.