### PR TITLE
Add hidden arguments and mtime in meta

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     tidewave (0.1.2)
-      fast-mcp (~> 1.3.0)
+      fast-mcp (~> 1.4.0)
       rack (>= 2.0)
       rails (>= 7.1.0)
 
@@ -126,7 +126,7 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.13.1)
-    fast-mcp (1.3.1)
+    fast-mcp (1.4.0)
       base64
       dry-schema (~> 1.14)
       json (~> 2.0)

--- a/lib/tidewave/tools/edit_project_file.rb
+++ b/lib/tidewave/tools/edit_project_file.rb
@@ -26,8 +26,7 @@ class Tidewave::Tools::EditProjectFile < Tidewave::Tools::Base
     required(:path).filled(:string).description("The path to the file to edit. It is relative to the project root.")
     required(:old_string).filled(:string).description("The string to search for")
     required(:new_string).filled(:string).description("The string to replace the old_string with")
-    # TODO: Make this a hidden field
-    optional(:atime).filled(:integer).description("The Unix timestamp this file was last accessed. Not to be used.")
+    optional(:atime).filled(:integer).hidden.description("The Unix timestamp this file was last accessed. Not to be used.")
   end
 
   def call(path:, old_string:, new_string:, atime: nil)
@@ -43,6 +42,8 @@ class Tidewave::Tools::EditProjectFile < Tidewave::Tools::Base
 
     new_content = old_content.sub(old_string, new_string)
     Tidewave::FileTracker.write_file(path, new_content)
+    _meta[:mtime] = Time.now
+
     "OK"
   end
 end

--- a/lib/tidewave/tools/write_project_file.rb
+++ b/lib/tidewave/tools/write_project_file.rb
@@ -15,13 +15,14 @@ class Tidewave::Tools::WriteProjectFile < Tidewave::Tools::Base
   arguments do
     required(:path).filled(:string).description("The path to the file to write. It is relative to the project root.")
     required(:content).filled(:string).description("The content to write to the file")
-    # TODO: Make this a hidden field
-    optional(:atime).filled(:integer).description("The Unix timestamp this file was last accessed. Not to be used.")
+    optional(:atime).filled(:integer).hidden.description("The Unix timestamp this file was last accessed. Not to be used.")
   end
 
   def call(path:, content:, atime: nil)
     Tidewave::FileTracker.validate_path_is_writable!(path, atime)
     Tidewave::FileTracker.write_file(path, content)
+    _meta[:mtime] = Time.now
+
     "OK"
   end
 end

--- a/spec/tools/edit_project_file_spec.rb
+++ b/spec/tools/edit_project_file_spec.rb
@@ -41,6 +41,15 @@ describe Tidewave::Tools::EditProjectFile do
     tool.call(path: path, old_string: old_string, new_string: new_string)
   end
 
+  it 'adds the mtime to the _meta' do
+    expect(Tidewave::FileTracker).to receive(:write_file).with(path, expected_content)
+
+    tool.call(path: path, old_string: old_string, new_string: new_string)
+
+    expect(tool._meta.keys).to eq([ :mtime ])
+    expect(tool._meta[:mtime]).to be_a(Time)
+  end
+
   it "raises an error if the file is not editable" do
     expect(Tidewave::FileTracker).to receive(:validate_path_is_editable!).with(path, nil).and_raise(ArgumentError, "File must be read first")
     expect(Tidewave::FileTracker).to receive(:write_file).never

--- a/spec/tools/get_source_location_spec.rb
+++ b/spec/tools/get_source_location_spec.rb
@@ -78,10 +78,10 @@ describe Tidewave::Tools::GetSourceLocation do
 
       context "when the module is found" do
         it "returns the correct result" do
-          expect(subject).to eq({
+          expect(subject).to eq([ {
             file_path: __FILE__,
             line_number: line_number
-          }.to_json)
+          }.to_json, {} ])
         end
       end
 

--- a/spec/tools/write_project_file_spec.rb
+++ b/spec/tools/write_project_file_spec.rb
@@ -50,6 +50,15 @@ describe Tidewave::Tools::WriteProjectFile do
       tool.call(path: path, content: content)
     end
 
+    it 'adds the mtime to the _meta' do
+      expect(Tidewave::FileTracker).to receive(:write_file).with(path, content)
+
+      tool.call(path: path, content: content)
+
+      expect(tool._meta.keys).to eq([ :mtime ])
+      expect(tool._meta[:mtime]).to be_a(Time)
+    end
+
     context "when writing different types of content" do
       it "handles empty content" do
         empty_content = ""

--- a/tidewave.gemspec
+++ b/tidewave.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.1.0"
-  spec.add_dependency "fast-mcp", "~> 1.3.0"
+  spec.add_dependency "fast-mcp", "~> 1.4.0"
   spec.add_dependency "rack", ">= 2.0"
 end


### PR DESCRIPTION
Bumps fast-mcp to v.1.4.0 and adds mtime to tool call results of write_project_file and read_project_file. Also adds hidden arguments.