### PR TITLE
Add line_offset and count parameters to read_project_file tool

### DIFF
--- a/lib/tidewave/file_tracker.rb
+++ b/lib/tidewave/file_tracker.rb
@@ -8,11 +8,21 @@ module Tidewave
       `git --git-dir #{git_root}/.git ls-files --cached --others --exclude-standard`.split("\n")
     end
 
-    def read_file(path)
+    def read_file(path, line_offset: 0, count: nil)
       full_path = file_full_path(path)
       # Explicitly read the mtime first to avoid race conditions
       mtime = File.mtime(full_path).to_i
-      [ mtime, File.read(full_path) ]
+      content = File.read(full_path)
+
+      if line_offset > 0 || count
+        lines = content.lines
+        start_idx = [ line_offset, 0 ].max
+        count = (count || lines.length)
+        selected_lines = lines[start_idx, count]
+        content = selected_lines ? selected_lines.join : ""
+      end
+
+      [ mtime, content ]
     end
 
     def write_file(path, content)

--- a/lib/tidewave/tools/read_project_file.rb
+++ b/lib/tidewave/tools/read_project_file.rb
@@ -7,16 +7,19 @@ class Tidewave::Tools::ReadProjectFile < Tidewave::Tools::Base
 
   tool_name "read_project_file"
   description <<~DESCRIPTION
-    Returns the contents of the given file. Matches the `resources/read` MCP method.
+    Returns the contents of the given file.
+    Supports an optional line_offset and count. To read the full file, only the path needs to be passed.
   DESCRIPTION
 
   arguments do
     required(:path).filled(:string).description("The path to the file to read. It is relative to the project root.")
+    optional(:line_offset).filled(:integer).description("Optional: the starting line offset from which to read. Defaults to 0.")
+    optional(:count).filled(:integer).description("Optional: the number of lines to read. Defaults to all.")
   end
 
-  def call(path:)
+  def call(path:, **keywords)
     Tidewave::FileTracker.validate_path_access!(path)
-    _meta[:mtime], contents = Tidewave::FileTracker.read_file(path)
+    _meta[:mtime], contents = Tidewave::FileTracker.read_file(path, **keywords)
     contents
   end
 end

--- a/spec/tools/read_project_file_spec.rb
+++ b/spec/tools/read_project_file_spec.rb
@@ -17,7 +17,8 @@ describe Tidewave::Tools::ReadProjectFile do
     it "returns the correct description" do
       expect(described_class.description).to eq(
         <<~DESCRIPTION
-          Returns the contents of the given file. Matches the `resources/read` MCP method.
+          Returns the contents of the given file.
+          Supports an optional line_offset and count. To read the full file, only the path needs to be passed.
         DESCRIPTION
       )
     end
@@ -30,6 +31,14 @@ describe Tidewave::Tools::ReadProjectFile do
           path: {
             type: "string",
             description: "The path to the file to read. It is relative to the project root."
+          },
+          line_offset: {
+            type: "number",
+            description: "Optional: the starting line offset from which to read. Defaults to 0."
+          },
+          count: {
+            type: "number",
+            description: "Optional: the number of lines to read. Defaults to all."
           }
         },
         required: [ "path" ],
@@ -57,6 +66,20 @@ describe Tidewave::Tools::ReadProjectFile do
 
     it "returns the file content" do
       expect(subject.call(path: file_path)).to eq(file_content)
+    end
+
+    it "returns specific lines when line_offset and count are provided" do
+      multiline_content = "line1\nline2\nline3\nline4\nline5\n"
+      allow(File).to receive(:read).with(full_path).and_return(multiline_content)
+
+      expect(subject.call(path: file_path, line_offset: 1, count: 2)).to eq("line2\nline3\n")
+    end
+
+    it "returns lines from offset to end when only line_offset is provided" do
+      multiline_content = "line1\nline2\nline3\nline4\nline5\n"
+      allow(File).to receive(:read).with(full_path).and_return(multiline_content)
+
+      expect(subject.call(path: file_path, line_offset: 3)).to eq("line4\nline5\n")
     end
 
     it "returns the mtime in metadata" do


### PR DESCRIPTION
- Update FileTracker to support line-based file reading
- Add comprehensive tests for new functionality

Closes #9

Prompt
======

We have an Elixir version of this project and we changed the read_project_file tool to read for a given count and line offset. Apply them to this Ruby version:
https://github.com/tidewave-ai/tidewave_phoenix/pull/14.diff