### PR TITLE
Fix issue to run tests when tidewave is installed

### DIFF
--- a/lib/tidewave/railtie.rb
+++ b/lib/tidewave/railtie.rb
@@ -10,7 +10,7 @@ module Tidewave
   class Railtie < Rails::Railtie
     config.tidewave = Tidewave::Configuration.new
 
-    initializer "tidewave.setup_mcp" do |app|
+    initializer "tidewave.setup_mcp", :group => :development do |app|
       # Prevent MCP server from being mounted if Rails is not running in development mode
       raise "For security reasons, Tidewave is only supported in development mode" unless Rails.env.development?
 

--- a/lib/tidewave/railtie.rb
+++ b/lib/tidewave/railtie.rb
@@ -10,7 +10,14 @@ module Tidewave
   class Railtie < Rails::Railtie
     config.tidewave = Tidewave::Configuration.new
 
-    initializer "tidewave.setup_mcp", :group => :development do |app|
+
+    initializer "tidewave.setup_mcp" do |app|
+      # Skip in test environments
+      if Rails.env.test?
+        Rails.logger.info("[Tidewave] Skipping MCP setup when testing")
+        next
+      end
+
       # Prevent MCP server from being mounted if Rails is not running in development mode
       raise "For security reasons, Tidewave is only supported in development mode" unless Rails.env.development?
 


### PR DESCRIPTION
Only run tidewave on development, otherwise it will fail when trying to run tests.


## Before:
```bash
$ bin/rails test
bin/rails aborted!
For security reasons, Tidewave is only supported in development mode
/Users/jose.coelho/dovetail/gondola/gondola-portal/config/environment.rb:5:in '<main>'
Tasks: TOP => test:prepare => tailwindcss:build => environment
```

## After:
```
$ bin/rails test

Done in 97ms
Running 352 tests in parallel using 8 processes
Run options: --seed 61117

# Running:

.....................................................................................................
```