### PR TITLE
Align edit_project_file tool with FileTracker.read_file return type

### DIFF
--- a/lib/tidewave/tools/edit_project_file.rb
+++ b/lib/tidewave/tools/edit_project_file.rb
@@ -33,7 +33,7 @@ class Tidewave::Tools::EditProjectFile < Tidewave::Tools::Base
     # Check if the file exists within the project root and has been read
     Tidewave::FileTracker.validate_path_is_editable!(path, atime)
 
-    old_content = Tidewave::FileTracker.read_file(path)
+    _mtime, old_content = Tidewave::FileTracker.read_file(path)
 
     # Ensure old_string is unique within the file
     scan_result = old_content.scan(old_string)

--- a/spec/tools/edit_project_file_spec.rb
+++ b/spec/tools/edit_project_file_spec.rb
@@ -17,7 +17,7 @@ describe Tidewave::Tools::EditProjectFile do
 
   before do
     allow(Tidewave::FileTracker).to receive(:validate_path_is_editable!)
-    allow(Tidewave::FileTracker).to receive(:read_file).and_return(file_content)
+    allow(Tidewave::FileTracker).to receive(:read_file).and_return([Time.now.to_i, file_content])
     allow(Tidewave::FileTracker).to receive(:write_file)
   end
 


### PR DESCRIPTION
Tidewave::FileTracker recently changed to return [mtime, content] but the edit_project_file tool was not kept in sync, the mock in its spec file hid the problem.