### PR TITLE
Do not log tidewave requests

### DIFF
--- a/lib/tidewave/quiet_requests_middleware.rb
+++ b/lib/tidewave/quiet_requests_middleware.rb
@@ -2,14 +2,14 @@
 
 class Tidewave::QuietRequestsMiddleware < Rails::Rack::Logger
   def initialize(app)
-    super(app)
+    @app = app
   end
 
   def call(env)
     if env["PATH_INFO"].start_with?("/tidewave")
-      Rails.logger.silence { super(env) }
+      Rails.logger.silence { @app.call(env) }
     else
-      super(env)
+      @app.call(env)
     end
   end
 end

--- a/lib/tidewave/quiet_requests_middleware.rb
+++ b/lib/tidewave/quiet_requests_middleware.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Tidewave::QuietRequestsMiddleware < Rails::Rack::Logger
+class Tidewave::QuietRequestsMiddleware
   def initialize(app)
     @app = app
   end

--- a/lib/tidewave/quiet_requests_middleware.rb
+++ b/lib/tidewave/quiet_requests_middleware.rb
@@ -6,7 +6,7 @@ class Tidewave::QuietRequestsMiddleware < Rails::Rack::Logger
   end
 
   def call(env)
-    if env["PATH_INFO"].include?("/tidewave")
+    if env["PATH_INFO"].start_with?("/tidewave")
       Rails.logger.silence { super(env) }
     else
       super(env)

--- a/lib/tidewave/quiet_requests_middleware.rb
+++ b/lib/tidewave/quiet_requests_middleware.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Tidewave::QuietRequestsMiddleware < Rails::Rack::Logger
+  def initialize(app)
+    super(app)
+  end
+
+  def call(env)
+    if env["PATH_INFO"].include?("/tidewave")
+      Rails.logger.silence { super(env) }
+    else
+      super(env)
+    end
+  end
+end

--- a/lib/tidewave/railtie.rb
+++ b/lib/tidewave/railtie.rb
@@ -49,7 +49,7 @@ module Tidewave
 
     initializer "tidewave.logging" do |app|
       # Do not pollute user logs with tidewave requests.
-      app.config.middleware.swap(Rails::Rack::Logger, Tidewave::QuietRequestsMiddleware)
+      app.middleware.insert_before(Rails::Rack::Logger, Tidewave::QuietRequestsMiddleware)
     end
   end
 end

--- a/lib/tidewave/railtie.rb
+++ b/lib/tidewave/railtie.rb
@@ -5,6 +5,7 @@ require "fileutils"
 require "tidewave/configuration"
 require "tidewave/middleware"
 require "tidewave/exceptions_middleware"
+require "tidewave/quiet_requests_middleware"
 
 gem_tools_path = File.expand_path("tools/**/*.rb", __dir__)
 Dir[gem_tools_path].each { |f| require f }
@@ -44,6 +45,11 @@ module Tidewave
       end
 
       app.middleware.insert_before(ActionDispatch::DebugExceptions, Tidewave::ExceptionsMiddleware)
+    end
+
+    initializer "tidewave.logging" do |app|
+      # Do not pollute user logs with tidewave requests.
+      app.config.middleware.swap(Rails::Rack::Logger, Tidewave::QuietRequestsMiddleware)
     end
   end
 end


### PR DESCRIPTION
This prevents /tidewave requests from being logged. One of the MCP tools is `get_logs` and including tidewave logs is unnecessary noise. This is particularly relevant for ping requests, which are currently logged every 5 seconds.