### PR TITLE
Fix `containers` typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ config.hosts << "company.local"
 config.tidewave.allow_remote_access = true
 ```
 
-If you want to use Docker for development, you either need to enable the configuration above or automatically redirect the relevant ports, as done by [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers). See our [containars](https://hexdocs.pm/tidewave/containers.html) guide for more information.
+If you want to use Docker for development, you either need to enable the configuration above or automatically redirect the relevant ports, as done by [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers). See our [containers](https://hexdocs.pm/tidewave/containers.html) guide for more information.
 
 ### Content security policy
 


### PR DESCRIPTION
Thanks for the cool project, very interesting!

I was just reading the README and wanted to open a quick pull request to update the word `containers` in the README.