### PR TITLE
Add /config endpoint and remove CSP/X-Frame-Options headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want to use Docker for development, you either need to enable the configu
 
 ### Content security policy
 
-If you have enabled Content-Security-Policy, Tidewave will automatically enable "unsafe-eval" under `script-src` in order for contextual browser testing to work correctly.
+If you have enabled Content-Security-Policy, Tidewave will automatically enable "unsafe-eval" under `script-src` in order for contextual browser testing to work correctly. It also disables the `frame-ancestors` directive.
 
 ### Web server requirements
 

--- a/lib/tidewave/middleware.rb
+++ b/lib/tidewave/middleware.rb
@@ -74,7 +74,6 @@ class Tidewave::Middleware
 
     # Remove CSP and X-Frame-Options headers for non-Tidewave routes
     # to allow embedding the app in Tidewave
-    headers.delete("Content-Security-Policy")
     headers.delete("X-Frame-Options")
 
     [ status, headers, body ]

--- a/lib/tidewave/railtie.rb
+++ b/lib/tidewave/railtie.rb
@@ -32,6 +32,8 @@ module Tidewave
           content_security_policy.directives["script-src"].try do |script_src|
             script_src << "'unsafe-eval'" unless script_src.include?("'unsafe-eval'")
           end
+
+          content_security_policy.directives.delete("frame-ancestors")
         end
       end
     end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Tidewave::Middleware do
 
   describe "header removal" do
     let(:downstream_app_with_headers) do
-      ->(env) { [ 200, { "Content-Security-Policy" => "default-src 'self'", "X-Frame-Options" => "DENY" }, [ "App with headers" ] ] }
+      ->(env) { [ 200, { "X-Frame-Options" => "DENY" }, [ "App with headers" ] ] }
     end
     let(:middleware_with_headers) { described_class.new(downstream_app_with_headers, config) }
 
@@ -42,14 +42,12 @@ RSpec.describe Tidewave::Middleware do
     it "removes CSP and X-Frame-Options headers from all responses" do
       get "/some-route"
       expect(last_response.status).to eq(200)
-      expect(last_response.headers["Content-Security-Policy"]).to be_nil
       expect(last_response.headers["X-Frame-Options"]).to be_nil
       expect(last_response.body).to eq("App with headers")
     end
 
     it "removes headers from tidewave routes as well" do
       get "/tidewave/some-sub-route"
-      expect(last_response.headers["Content-Security-Policy"]).to be_nil
       expect(last_response.headers["X-Frame-Options"]).to be_nil
     end
   end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -33,10 +33,9 @@ RSpec.describe Tidewave::Middleware do
     let(:downstream_app_with_headers) do
       ->(env) { [ 200, { "X-Frame-Options" => "DENY" }, [ "App with headers" ] ] }
     end
-    let(:middleware_with_headers) { described_class.new(downstream_app_with_headers, config) }
 
     def app
-      middleware_with_headers
+      described_class.new(downstream_app_with_headers, config)
     end
 
     it "removes CSP and X-Frame-Options headers from all responses" do

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Tidewave::Middleware do
       described_class.new(downstream_app_with_headers, config)
     end
 
-    it "removes CSP and X-Frame-Options headers from all responses" do
+    it "removes X-Frame-Options headers from all responses" do
       get "/some-route"
       expect(last_response.status).to eq(200)
       expect(last_response.headers["X-Frame-Options"]).to be_nil


### PR DESCRIPTION
See https://github.com/tidewave-ai/tidewave_phoenix/pull/193

- Add GET /tidewave/config endpoint that returns JSON configuration
- Remove Content-Security-Policy and X-Frame-Options headers from all responses to allow embedding the app in Tidewave
- Extract config generation into reusable config_data method
- Add tests for new /config endpoint and header removal functionality

This mirrors the functionality from the Elixir/Phoenix version while following Rails/Rack conventions.

🤖 Generated with [Claude Code](https://claude.ai/code)