### PR TITLE
fix(mcp): spec-compliant Streamable HTTP transport + Rack 3 headers

### DIFF
--- a/lib/tidewave.rb
+++ b/lib/tidewave.rb
@@ -85,7 +85,7 @@ class Tidewave
 
   def strip_x_frame_options(response)
     status, headers, body = response
-    headers.delete("X-Frame-Options")
+    headers.delete("x-frame-options")
     [ status, headers, body ]
   end
 
@@ -107,7 +107,7 @@ class Tidewave
   end
 
   def config_endpoint(request)
-    json_response(config_data(request), headers: { "Access-Control-Allow-Origin" => "*" })
+    json_response(config_data(request), headers: { "access-control-allow-origin" => "*" })
   end
 
   def mcp_endpoint(request)
@@ -174,21 +174,25 @@ class Tidewave
 
   def method_not_allowed
     status, headers, body = text_response(405, "Method Not Allowed")
-    [ status, headers.merge("Allow" => "POST"), body ]
+    [ status, headers.merge("allow" => "POST"), body ]
   end
 
   def accepted_response
-    [ 202, { "Content-Length" => "0" }, [] ]
+    [ 202, { "content-length" => "0" }, [] ]
   end
 
   def text_response(status, message)
     [ status, response_headers("text/plain; charset=utf-8", message), [ message ] ]
   end
 
+  # Rack 3 requires response header keys to be lowercase. Capitalized keys break
+  # case-sensitive middleware such as Rack::Deflater, which strips "content-length"
+  # before gzipping; a surviving "Content-Length" leaves a stale (uncompressed)
+  # length on the compressed body and hangs spec-compliant HTTP clients.
   def response_headers(content_type, body)
     {
-      "Content-Type" => content_type,
-      "Content-Length" => body.bytesize.to_s
+      "content-type" => content_type,
+      "content-length" => body.bytesize.to_s
     }
   end
 

--- a/lib/tidewave.rb
+++ b/lib/tidewave.rb
@@ -72,7 +72,9 @@ class Tidewave
       when [ "POST", [ TIDEWAVE_ROUTE, MCP_ROUTE ] ]
         mcp_endpoint(request)
       else
-        not_found
+        # The MCP Streamable HTTP transport requires the MCP endpoint to answer
+        # non-POST methods with 405 (GET without SSE support, DELETE, etc.)
+        path == [ TIDEWAVE_ROUTE, MCP_ROUTE ] ? method_not_allowed() : not_found()
       end
     else
       strip_x_frame_options(@app.call(env))
@@ -109,21 +111,40 @@ class Tidewave
   end
 
   def mcp_endpoint(request)
-    body = request.body.read
+    message = JSON.parse(request.body.read)
 
-    message = JSON.parse(body)
-    validation_error = validate_jsonrpc_message(message)
-    return jsonrpc_error_response(nil, -32600, validation_error) if validation_error
-
-    response = handle_mcp_message(message)
-    return json_response({ "status" => "ok" }, status: 202) if response.nil?
-
-    json_response(response)
+    if message.is_a?(Array)
+      handle_mcp_batch(message)
+    else
+      handle_mcp_single(message)
+    end
   rescue JSON::ParserError
-    jsonrpc_error_response(nil, -32700, "Parse error")
+    jsonrpc_error_response(nil, -32700, "Parse error", status: 400)
   rescue StandardError => error
     @logger&.error("Error handling MCP request: #{error.message}")
     jsonrpc_error_response(nil, -32603, "Internal error")
+  end
+
+  def handle_mcp_single(message)
+    validation_error = validate_jsonrpc_message(message)
+    return jsonrpc_error_response(nil, -32600, validation_error, status: 400) if validation_error
+
+    response = handle_mcp_message(message)
+    response.nil? ? accepted_response : json_response(response)
+  end
+
+  def handle_mcp_batch(messages)
+    return jsonrpc_error_response(nil, -32600, "Invalid Request", status: 400) if messages.empty?
+
+    responses = messages.map { |message| handle_mcp_batch_message(message) }.compact
+    responses.empty? ? accepted_response : json_response(responses)
+  end
+
+  def handle_mcp_batch_message(message)
+    validation_error = validate_jsonrpc_message(message)
+    return jsonrpc_error_response_body(nil, -32600, validation_error) if validation_error
+
+    handle_mcp_message(message)
   end
 
   def config_data(request)
@@ -149,6 +170,15 @@ class Tidewave
 
   def not_found
     text_response(404, "Not Found")
+  end
+
+  def method_not_allowed
+    status, headers, body = text_response(405, "Method Not Allowed")
+    [ status, headers.merge("Allow" => "POST"), body ]
+  end
+
+  def accepted_response
+    [ 202, { "Content-Length" => "0" }, [] ]
   end
 
   def text_response(status, message)
@@ -192,7 +222,7 @@ class Tidewave
 
     has_id = message.key?("id")
     has_method = message.key?("method")
-    has_result = message.key?("result")
+    has_result = message.key?("result") || message.key?("error")
 
     return nil if has_method
     return nil if has_id && has_result
@@ -200,14 +230,17 @@ class Tidewave
     "Invalid JSON-RPC message structure"
   end
 
+  # Returns the JSON-RPC response for a request, or nil for messages that
+  # must not be replied to (notifications and client-sent responses), which
+  # the transport acknowledges with 202 Accepted.
   def handle_mcp_message(message)
+    return nil unless message.key?("method") && message.key?("id")
+
     method = message["method"]
     request_id = message["id"]
     params = message["params"].is_a?(Hash) ? message["params"] : {}
 
     case method
-    when "notifications/initialized", "notifications/cancelled"
-      nil
     when "ping"
       jsonrpc_success_response_body(request_id, {})
     when "initialize"
@@ -216,6 +249,12 @@ class Tidewave
       jsonrpc_success_response_body(request_id, { "tools" => tool_definitions })
     when "tools/call"
       handle_tool_call(request_id, params)
+    when "prompts/list"
+      jsonrpc_success_response_body(request_id, { "prompts" => [] })
+    when "resources/list"
+      jsonrpc_success_response_body(request_id, { "resources" => [] })
+    when "resources/templates/list"
+      jsonrpc_success_response_body(request_id, { "resourceTemplates" => [] })
     else
       {
         "jsonrpc" => "2.0",
@@ -233,14 +272,9 @@ class Tidewave
     client_version = params["protocolVersion"]
     return jsonrpc_error_response_body(request_id, -32602, "Protocol version is required") if client_version.nil? || client_version.empty?
 
-    if client_version < PROTOCOL_VERSION
-      return jsonrpc_error_response_body(
-        request_id,
-        -32602,
-        "Unsupported protocol version. Server supports #{PROTOCOL_VERSION} or later"
-      )
-    end
-
+    # Version negotiation: when the client requests a version we don't
+    # support, we respond with the version we do support and the client
+    # decides whether to continue or disconnect.
     jsonrpc_success_response_body(request_id, {
       "protocolVersion" => PROTOCOL_VERSION,
       "capabilities" => { "tools" => { "listChanged" => false } },
@@ -276,8 +310,8 @@ class Tidewave
     }
   end
 
-  def jsonrpc_error_response(request_id, code, message)
-    json_response(jsonrpc_error_response_body(request_id, code, message))
+  def jsonrpc_error_response(request_id, code, message, status: 200)
+    json_response(jsonrpc_error_response_body(request_id, code, message), status: status)
   end
 
   def jsonrpc_error_response_body(request_id, code, message)

--- a/test/mcp_test.rb
+++ b/test/mcp_test.rb
@@ -33,10 +33,24 @@ class TidewaveMcpTest < Minitest::Test
     assert_equal({}, payload["result"])
   end
 
+  def test_get_mcp_returns_method_not_allowed
+    status, headers, _body = perform_request(@app, path: "/tidewave/mcp", method: "GET")
+
+    assert_equal 405, status
+    assert_equal "POST", headers["Allow"]
+  end
+
+  def test_delete_mcp_returns_method_not_allowed
+    status, headers, _body = perform_request(@app, path: "/tidewave/mcp", method: "DELETE")
+
+    assert_equal 405, status
+    assert_equal "POST", headers["Allow"]
+  end
+
   def test_empty_request_body_returns_parse_error
     status, _headers, body = perform_request(@app, path: "/tidewave/mcp", method: "POST")
 
-    assert_equal 200, status
+    assert_equal 400, status
 
     payload = JSON.parse(body)
     assert_equal(-32700, payload.dig("error", "code"))
@@ -46,7 +60,7 @@ class TidewaveMcpTest < Minitest::Test
   def test_invalid_json_returns_parse_error
     status, _headers, body = perform_request(@app, path: "/tidewave/mcp", method: "POST", body: "invalid json")
 
-    assert_equal 200, status
+    assert_equal 400, status
 
     payload = JSON.parse(body)
     assert_equal(-32700, payload.dig("error", "code"))
@@ -61,15 +75,15 @@ class TidewaveMcpTest < Minitest::Test
       body: JSON.generate({ jsonrpc: "1.0", method: "ping", id: 1 })
     )
 
-    assert_equal 200, status
+    assert_equal 400, status
 
     payload = JSON.parse(body)
     assert_equal(-32600, payload.dig("error", "code"))
     assert_equal("Invalid JSON-RPC version", payload.dig("error", "message"))
   end
 
-  def test_notification_returns_accepted
-    status, headers, body = perform_request(
+  def test_notification_returns_accepted_with_no_body
+    status, _headers, body = perform_request(
       @app,
       path: "/tidewave/mcp",
       method: "POST",
@@ -77,8 +91,130 @@ class TidewaveMcpTest < Minitest::Test
     )
 
     assert_equal 202, status
-    assert_equal "application/json", headers["Content-Type"]
-    assert_equal({ "status" => "ok" }, JSON.parse(body))
+    assert_equal "", body
+  end
+
+  def test_unknown_notification_returns_accepted_with_no_body
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({ jsonrpc: "2.0", method: "notifications/roots/list_changed" })
+    )
+
+    assert_equal 202, status
+    assert_equal "", body
+  end
+
+  def test_client_response_returns_accepted_with_no_body
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({ jsonrpc: "2.0", id: 1, result: {} })
+    )
+
+    assert_equal 202, status
+    assert_equal "", body
+  end
+
+  def test_client_error_response_returns_accepted_with_no_body
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({ jsonrpc: "2.0", id: 1, error: { code: -32601, message: "Method not found" } })
+    )
+
+    assert_equal 202, status
+    assert_equal "", body
+  end
+
+  def test_batch_of_requests_returns_batched_responses
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate([
+        { jsonrpc: "2.0", method: "ping", id: 1 },
+        { jsonrpc: "2.0", method: "tools/list", id: 2 }
+      ])
+    )
+
+    assert_equal 200, status
+
+    payload = JSON.parse(body)
+    assert_instance_of Array, payload
+    assert_equal [ 1, 2 ], payload.map { |response| response["id"] }
+    assert_equal({}, payload[0]["result"])
+    assert_equal DEFAULT_TOOL_NAMES, payload[1].dig("result", "tools").map { |tool| tool["name"] }.sort
+  end
+
+  def test_batch_of_notifications_returns_accepted_with_no_body
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate([
+        { jsonrpc: "2.0", method: "notifications/initialized" },
+        { jsonrpc: "2.0", method: "notifications/cancelled" }
+      ])
+    )
+
+    assert_equal 202, status
+    assert_equal "", body
+  end
+
+  def test_batch_excludes_responses_for_notifications
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate([
+        { jsonrpc: "2.0", method: "ping", id: 1 },
+        { jsonrpc: "2.0", method: "notifications/initialized" }
+      ])
+    )
+
+    assert_equal 200, status
+
+    payload = JSON.parse(body)
+    assert_equal 1, payload.length
+    assert_equal 1, payload[0]["id"]
+  end
+
+  def test_batch_with_invalid_entry_includes_error_response
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate([
+        { jsonrpc: "2.0", method: "ping", id: 1 },
+        42
+      ])
+    )
+
+    assert_equal 200, status
+
+    payload = JSON.parse(body)
+    assert_equal 2, payload.length
+    assert_equal({}, payload[0]["result"])
+    assert_nil payload[1]["id"]
+    assert_equal(-32600, payload[1].dig("error", "code"))
+  end
+
+  def test_empty_batch_returns_invalid_request
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate([])
+    )
+
+    assert_equal 400, status
+
+    payload = JSON.parse(body)
+    assert_equal(-32600, payload.dig("error", "code"))
   end
 
   def test_initialize_requires_protocol_version
@@ -117,6 +253,62 @@ class TidewaveMcpTest < Minitest::Test
     assert_equal "tidewave", payload.dig("result", "serverInfo", "name")
     assert_equal Tidewave::VERSION, payload.dig("result", "serverInfo", "version")
     assert_equal DEFAULT_TOOL_NAMES, payload.dig("result", "tools").map { |tool| tool["name"] }.sort
+  end
+
+  def test_initialize_negotiates_unsupported_protocol_version
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: { protocolVersion: "2024-11-05" }
+      })
+    )
+
+    assert_equal 200, status
+
+    payload = JSON.parse(body)
+    assert_nil payload["error"]
+    assert_equal Tidewave::PROTOCOL_VERSION, payload.dig("result", "protocolVersion")
+  end
+
+  def test_prompts_list_returns_empty_list
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({ jsonrpc: "2.0", method: "prompts/list", id: 1 })
+    )
+
+    assert_equal 200, status
+    assert_equal [], JSON.parse(body).dig("result", "prompts")
+  end
+
+  def test_resources_list_returns_empty_list
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({ jsonrpc: "2.0", method: "resources/list", id: 1 })
+    )
+
+    assert_equal 200, status
+    assert_equal [], JSON.parse(body).dig("result", "resources")
+  end
+
+  def test_resources_templates_list_returns_empty_list
+    status, _headers, body = perform_request(
+      @app,
+      path: "/tidewave/mcp",
+      method: "POST",
+      body: JSON.generate({ jsonrpc: "2.0", method: "resources/templates/list", id: 1 })
+    )
+
+    assert_equal 200, status
+    assert_equal [], JSON.parse(body).dig("result", "resourceTemplates")
   end
 
   def test_tools_list_returns_loaded_tools

--- a/test/mcp_test.rb
+++ b/test/mcp_test.rb
@@ -25,7 +25,7 @@ class TidewaveMcpTest < Minitest::Test
     )
 
     assert_equal 200, status
-    assert_equal "application/json", headers["Content-Type"]
+    assert_equal "application/json", headers["content-type"]
 
     payload = JSON.parse(body)
     assert_equal "2.0", payload["jsonrpc"]
@@ -37,14 +37,14 @@ class TidewaveMcpTest < Minitest::Test
     status, headers, _body = perform_request(@app, path: "/tidewave/mcp", method: "GET")
 
     assert_equal 405, status
-    assert_equal "POST", headers["Allow"]
+    assert_equal "POST", headers["allow"]
   end
 
   def test_delete_mcp_returns_method_not_allowed
     status, headers, _body = perform_request(@app, path: "/tidewave/mcp", method: "DELETE")
 
     assert_equal 405, status
-    assert_equal "POST", headers["Allow"]
+    assert_equal "POST", headers["allow"]
   end
 
   def test_empty_request_body_returns_parse_error

--- a/test/rack_lint_test.rb
+++ b/test/rack_lint_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "rack/lint"
+
+# Rack::Lint is Rack's official conformance validator: it raises LintError on
+# any spec violation (uppercase header keys, bad status/body shapes, etc.).
+# Driving every Tidewave endpoint through it proves the middleware is Rack 3
+# conformant.
+class TidewaveRackLintTest < Minitest::Test
+  def setup
+    downstream = ->(_env) { [ 200, { "content-type" => "text/plain" }, [ "ok" ] ] }
+    @app = Rack::Lint.new(Tidewave.new(downstream, project_name: "lint", allow_remote_access: true))
+    @mock = Rack::MockRequest.new(@app)
+    @init = JSON.generate(jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: Tidewave::PROTOCOL_VERSION })
+  end
+
+  def assert_lint_ok(&block)
+    response = block.call
+    assert_kind_of Integer, response.status
+  rescue Rack::Lint::LintError => error
+    flunk "Rack::Lint violation: #{error.message.lines.first.strip}"
+  end
+
+  def test_home_endpoint_is_rack_conformant
+    assert_lint_ok { @mock.get("/tidewave") }
+  end
+
+  def test_config_endpoint_is_rack_conformant
+    assert_lint_ok { @mock.get("/tidewave/config") }
+  end
+
+  def test_mcp_post_is_rack_conformant
+    assert_lint_ok { @mock.post("/tidewave/mcp", input: @init) }
+  end
+
+  def test_mcp_405_is_rack_conformant
+    assert_lint_ok { @mock.get("/tidewave/mcp") }
+    assert_lint_ok { @mock.request("DELETE", "/tidewave/mcp") }
+  end
+
+  def test_mcp_202_notification_is_rack_conformant
+    assert_lint_ok { @mock.post("/tidewave/mcp", input: JSON.generate(jsonrpc: "2.0", method: "notifications/initialized")) }
+  end
+
+  def test_mcp_batch_is_rack_conformant
+    assert_lint_ok { @mock.post("/tidewave/mcp", input: JSON.generate([ { jsonrpc: "2.0", id: 1, method: "ping" } ])) }
+  end
+
+  def test_mcp_error_responses_are_rack_conformant
+    assert_lint_ok { @mock.post("/tidewave/mcp", input: "not json") }
+  end
+
+  def test_pass_through_is_rack_conformant
+    assert_lint_ok { @mock.get("/") }
+  end
+end

--- a/test/tidewave_test.rb
+++ b/test/tidewave_test.rb
@@ -7,7 +7,7 @@ class TidewaveTest < Minitest::Test
     @downstream_calls = []
     @downstream_app = lambda do |env|
       @downstream_calls << env
-      [ 200, { "Content-Type" => "text/plain", "X-Frame-Options" => "DENY" }, [ "demo response" ] ]
+      [ 200, { "content-type" => "text/plain", "x-frame-options" => "DENY" }, [ "demo response" ] ]
     end
 
     @app = Tidewave.new(@downstream_app, allow_remote_access: true, project_name: "test-app")
@@ -17,7 +17,7 @@ class TidewaveTest < Minitest::Test
     status, headers, body = perform_request(@app, path: "/")
 
     assert_equal 200, status
-    assert_equal "text/plain", headers["Content-Type"]
+    assert_equal "text/plain", headers["content-type"]
     assert_equal "demo response", body
     assert_equal 1, @downstream_calls.length
   end
@@ -26,14 +26,14 @@ class TidewaveTest < Minitest::Test
     status, headers, _body = perform_request(@app, path: "/")
 
     assert_equal 200, status
-    assert_nil headers["X-Frame-Options"]
+    assert_nil headers["x-frame-options"]
   end
 
   def test_home_route_returns_html
     status, headers, body = perform_request(@app, path: "/tidewave")
 
     assert_equal 200, status
-    assert_equal "text/html", headers["Content-Type"]
+    assert_equal "text/html", headers["content-type"]
     assert_includes body, "https://tidewave.ai/tc/tc.js"
     refute_includes body.downcase, "tidewave:config"
   end
@@ -61,7 +61,7 @@ class TidewaveTest < Minitest::Test
     status, headers, body = perform_request(app, path: "/tidewave/config", remote_addr: "192.168.1.100")
 
     assert_equal 200, status
-    assert_equal "application/json", headers["Content-Type"]
+    assert_equal "application/json", headers["content-type"]
     assert_includes body, "\"tidewave_version\""
   end
 
@@ -72,7 +72,7 @@ class TidewaveTest < Minitest::Test
       status, headers, body = perform_request(app, path: "/tidewave/config", remote_addr: ip)
 
       assert_equal 200, status, "expected #{ip} to be accepted as a loopback address"
-      assert_equal "application/json", headers["Content-Type"]
+      assert_equal "application/json", headers["content-type"]
       assert_includes body, "\"tidewave_version\""
     end
   end
@@ -108,8 +108,8 @@ class TidewaveTest < Minitest::Test
     )
 
     assert_equal 200, status
-    assert_equal "application/json", headers["Content-Type"]
-    assert_equal "*", headers["Access-Control-Allow-Origin"]
+    assert_equal "application/json", headers["content-type"]
+    assert_equal "*", headers["access-control-allow-origin"]
 
     payload = JSON.parse(body)
     assert_equal "rack", payload["framework_type"]
@@ -188,7 +188,7 @@ class TidewaveTest < Minitest::Test
     status, headers, body = perform_request(@app, path: "/tidewave/config", origin: "http://localhost:4001")
 
     assert_equal 200, status
-    assert_equal "*", headers["Access-Control-Allow-Origin"]
+    assert_equal "*", headers["access-control-allow-origin"]
     assert_includes body, "\"tidewave_version\""
   end
 
@@ -204,7 +204,7 @@ class TidewaveTest < Minitest::Test
     status, headers, body = perform_request(@app, path: "/tidewave/config")
 
     assert_equal 200, status
-    assert_equal "application/json", headers["Content-Type"]
+    assert_equal "application/json", headers["content-type"]
     assert_includes body, "\"tidewave_version\""
   end
 


### PR DESCRIPTION
## Problem

Some MCP clients (e.g. opencode) could not connect and reported the Tidewave MCP server as failed.

I discovered this while trying to use OpenCode with Tidewave Rails against the open source Once Campfire app.

## Root cause (the `Rack::Deflater` hang)

Rack 3 requires response header keys to be lowercase. Tidewave emitted capitalized names (`Content-Type`, `Content-Length`, …). `Rack::Deflater` strips the lowercase `content-length` header before gzipping, but the capitalized `Content-Length` survived — leaving a stale, uncompressed length on the gzipped body. Clients that honor `Content-Length` (e.g. opencode's MCP SDK over undici, which sends `Accept-Encoding: gzip`) then wait for bytes that never arrive and time out.

## Solution

- Make it MCP Streamable HTTP transport compliant with MCP spec (2025-03-26)
- Make it Rack 3 compliant